### PR TITLE
tweak tests for validateParams

### DIFF
--- a/clover.xml
+++ b/clover.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1686848033">
-  <project timestamp="1686848033">
+<coverage generated="1690498949">
+  <project timestamp="1690498949">
     <file name="/home/david/Projects/ebay-oauth-php-client/src/EbayOauthToken.php">
       <class name="EbayOauthToken\EbayOauthToken" namespace="global">
-        <metrics complexity="24" methods="9" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="47" coveredstatements="47" elements="56" coveredelements="56"/>
+        <metrics complexity="25" methods="9" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="48" coveredstatements="48" elements="57" coveredelements="57"/>
       </class>
-      <line num="27" type="method" name="__construct" visibility="public" complexity="3" crap="3" count="17"/>
-      <line num="29" type="stmt" count="17"/>
+      <line num="27" type="method" name="__construct" visibility="public" complexity="3" crap="3" count="18"/>
+      <line num="29" type="stmt" count="18"/>
       <line num="30" type="stmt" count="1"/>
-      <line num="33" type="stmt" count="16"/>
-      <line num="34" type="stmt" count="15"/>
+      <line num="33" type="stmt" count="17"/>
+      <line num="34" type="stmt" count="16"/>
       <line num="44" type="method" name="getApplicationToken" visibility="public" complexity="2" crap="2" count="2"/>
       <line num="46" type="stmt" count="2"/>
       <line num="48" type="stmt" count="2"/>
@@ -19,8 +19,8 @@
       <line num="54" type="stmt" count="2"/>
       <line num="55" type="stmt" count="2"/>
       <line num="56" type="stmt" count="2"/>
-      <line num="69" type="method" name="generateUserAuthorizationUrl" visibility="public" complexity="9" crap="9" count="5"/>
-      <line num="71" type="stmt" count="5"/>
+      <line num="69" type="method" name="generateUserAuthorizationUrl" visibility="public" complexity="9" crap="9" count="6"/>
+      <line num="71" type="stmt" count="6"/>
       <line num="73" type="stmt" count="5"/>
       <line num="74" type="stmt" count="5"/>
       <line num="75" type="stmt" count="4"/>
@@ -44,54 +44,55 @@
       <line num="109" type="stmt" count="1"/>
       <line num="110" type="stmt" count="1"/>
       <line num="111" type="stmt" count="1"/>
-      <line num="122" type="method" name="getAccessToken" visibility="public" complexity="4" crap="4" count="3"/>
-      <line num="124" type="stmt" count="3"/>
-      <line num="125" type="stmt" count="3"/>
-      <line num="126" type="stmt" count="2"/>
-      <line num="127" type="stmt" count="2"/>
-      <line num="128" type="stmt" count="1"/>
-      <line num="130" type="stmt" count="1"/>
-      <line num="131" type="stmt" count="1"/>
-      <line num="140" type="method" name="setRefreshToken" visibility="public" complexity="1" crap="1" count="1"/>
-      <line num="142" type="stmt" count="1"/>
-      <line num="143" type="stmt" count="1"/>
-      <line num="151" type="method" name="getRefreshToken" visibility="public" complexity="1" crap="1" count="2"/>
-      <line num="153" type="stmt" count="2"/>
-      <line num="161" type="method" name="getCredentials" visibility="public" complexity="1" crap="1" count="1"/>
-      <line num="163" type="stmt" count="1"/>
-      <line num="171" type="method" name="getGrantType" visibility="public" complexity="1" crap="1" count="1"/>
-      <line num="173" type="stmt" count="1"/>
-      <metrics loc="176" ncloc="109" classes="1" methods="9" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="47" coveredstatements="47" elements="56" coveredelements="56"/>
+      <line num="125" type="method" name="getAccessToken" visibility="public" complexity="5" crap="5" count="3"/>
+      <line num="127" type="stmt" count="3"/>
+      <line num="130" type="stmt" count="3"/>
+      <line num="131" type="stmt" count="3"/>
+      <line num="132" type="stmt" count="3"/>
+      <line num="133" type="stmt" count="3"/>
+      <line num="134" type="stmt" count="1"/>
+      <line num="136" type="stmt" count="2"/>
+      <line num="137" type="stmt" count="2"/>
+      <line num="146" type="method" name="setRefreshToken" visibility="public" complexity="1" crap="1" count="1"/>
+      <line num="148" type="stmt" count="1"/>
+      <line num="149" type="stmt" count="1"/>
+      <line num="157" type="method" name="getRefreshToken" visibility="public" complexity="1" crap="1" count="2"/>
+      <line num="159" type="stmt" count="2"/>
+      <line num="167" type="method" name="getCredentials" visibility="public" complexity="1" crap="1" count="1"/>
+      <line num="169" type="stmt" count="1"/>
+      <line num="177" type="method" name="getGrantType" visibility="public" complexity="1" crap="1" count="1"/>
+      <line num="179" type="stmt" count="1"/>
+      <metrics loc="182" ncloc="110" classes="1" methods="9" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="48" coveredstatements="48" elements="57" coveredelements="57"/>
     </file>
     <file name="/home/david/Projects/ebay-oauth-php-client/src/Request.php">
-      <line num="7" type="stmt" count="3"/>
-      <line num="8" type="stmt" count="3"/>
-      <line num="10" type="stmt" count="3"/>
-      <line num="11" type="stmt" count="3"/>
-      <line num="12" type="stmt" count="3"/>
-      <line num="13" type="stmt" count="3"/>
-      <line num="14" type="stmt" count="3"/>
-      <line num="15" type="stmt" count="3"/>
-      <line num="16" type="stmt" count="3"/>
-      <line num="17" type="stmt" count="3"/>
-      <line num="18" type="stmt" count="3"/>
-      <line num="19" type="stmt" count="3"/>
-      <line num="20" type="stmt" count="3"/>
-      <line num="22" type="stmt" count="3"/>
+      <line num="7" type="stmt" count="4"/>
+      <line num="8" type="stmt" count="4"/>
+      <line num="10" type="stmt" count="4"/>
+      <line num="11" type="stmt" count="4"/>
+      <line num="12" type="stmt" count="4"/>
+      <line num="13" type="stmt" count="4"/>
+      <line num="14" type="stmt" count="4"/>
+      <line num="15" type="stmt" count="4"/>
+      <line num="16" type="stmt" count="4"/>
+      <line num="17" type="stmt" count="4"/>
+      <line num="18" type="stmt" count="4"/>
+      <line num="19" type="stmt" count="4"/>
+      <line num="20" type="stmt" count="4"/>
+      <line num="22" type="stmt" count="4"/>
       <metrics loc="23" ncloc="23" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="14" coveredstatements="14" elements="14" coveredelements="14"/>
     </file>
     <file name="/home/david/Projects/ebay-oauth-php-client/src/Utilities.php">
-      <line num="7" type="stmt" count="15"/>
-      <line num="9" type="stmt" count="15"/>
-      <line num="11" type="stmt" count="15"/>
+      <line num="7" type="stmt" count="16"/>
+      <line num="9" type="stmt" count="16"/>
+      <line num="11" type="stmt" count="16"/>
       <line num="12" type="stmt" count="1"/>
-      <line num="15" type="stmt" count="14"/>
-      <line num="17" type="stmt" count="14"/>
-      <line num="22" type="stmt" count="12"/>
+      <line num="15" type="stmt" count="15"/>
+      <line num="17" type="stmt" count="15"/>
+      <line num="22" type="stmt" count="13"/>
       <line num="23" type="stmt" count="1"/>
-      <line num="25" type="stmt" count="11"/>
+      <line num="25" type="stmt" count="12"/>
       <line num="26" type="stmt" count="1"/>
-      <line num="28" type="stmt" count="10"/>
+      <line num="28" type="stmt" count="11"/>
       <line num="29" type="stmt" count="1"/>
       <line num="35" type="stmt" count="1"/>
       <line num="36" type="stmt" count="1"/>
@@ -101,6 +102,6 @@
       <line num="41" type="stmt" count="1"/>
       <metrics loc="42" ncloc="42" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="18" coveredstatements="18" elements="18" coveredelements="18"/>
     </file>
-    <metrics files="3" loc="241" ncloc="174" classes="1" methods="9" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="79" coveredstatements="79" elements="88" coveredelements="88"/>
+    <metrics files="3" loc="247" ncloc="175" classes="1" methods="9" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="80" coveredstatements="80" elements="89" coveredelements="89"/>
   </project>
 </coverage>

--- a/test/EbayAuthTokenTest.php
+++ b/test/EbayAuthTokenTest.php
@@ -168,7 +168,7 @@ class EbayAuthTokenTest extends TestCase
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Scopes is required');
-        $ebayOauthToken->getAccessToken('SANDBOX', 'XXYYZZ1234', null);
+        $ebayOauthToken->generateUserAuthorizationUrl('PRODUCTION', null);
     }
 
     public function testValidateParamsWithoutCredentialsShouldFail() 
@@ -214,9 +214,20 @@ class EbayAuthTokenTest extends TestCase
         $ebayOauthToken = new EbayOauthToken(['filePath' => __DIR__.'/test.json']);
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("Refresh token is required, to generate refresh token use exchangeCodeForAccessToken method");
+        $this->expectExceptionMessage("Refresh token is required - to generate refresh token use exchangeCodeForAccessToken method");
 
         $ebayOauthToken->getAccessToken('PRODUCTION', null);
+    }
+
+    public function testGetAccessTokenWithNullScopes()
+    {
+        $ebayOauthToken = new EbayOauthToken(['filePath' => __DIR__.'/test.json']);
+
+        $res = $ebayOauthToken->getAccessToken('PRODUCTION', 'XXYYZZ1234', null);
+
+        $this->assertNotEmpty($res);
+
+        $this->assertEquals('QWESJAHS12323OP', json_decode($res)->access_token);
     }
 
     public function testSetRefreshToken()


### PR DESCRIPTION
Also modified the logic of how `getAccessToken` works with scopes - since it requires a refresh token, we don't have to worry about having `scopes` as a required parameter.  The API will infer the scopes from the refresh token's original consent grant - so this parameter should be optional.